### PR TITLE
Avoid ZeroDivisionError comparing non-overlapping sequences

### DIFF
--- a/dendropy/calculate/popgenstat.py
+++ b/dendropy/calculate/popgenstat.py
@@ -63,7 +63,7 @@ def _count_differences(char_sequences, state_alphabet, ignore_uncertain=True):
                 if f1 != f2:
                     diff += 1
             sum_diff += float(diff)
-            mean_diff += float(diff) / counted
+            mean_diff += (float(diff) / counted) if counted>0 else float(diff)
             sq_diff += (diff ** 2)
     return sum_diff, mean_diff / comps, sq_diff
 


### PR DESCRIPTION
If the input alignment contains a pair of **sequences that do not overlap** (except in gaps) a `ZeroDivisionError` will occur at in `_count_differences` (popgenstat.py:66).
A possible silent (and correct?) way to handle it is to report 0 differences.

Try [this alignment](https://github.com/hdetering/DendroPy/files/123378/412825_coding.fasta.txt) to reproduce the error.
